### PR TITLE
fix: 修复 fast-glob 的 ignore 参数的处理方式，直接传递而非转换路径模式

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -254,7 +254,7 @@ function listFiles(dir: string, options: fg.Options = {}) {
   const source = FILE_EXTENSIONS.map(ext => `${fg.convertPathToPattern(`${dir}`)}/**/*.${ext}`);
   const files = fg.sync(source, {
     cwd: cwd ? fg.convertPathToPattern(cwd) : undefined,
-    ignore: ignore.map(fg.convertPathToPattern),
+    ignore,
     deep,
     ...others,
     onlyFiles: true,


### PR DESCRIPTION
解决 mac\linux 平台下的路径转义问题 resolved #8